### PR TITLE
Feature/watch namespaces list option

### DIFF
--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	esv1alpha1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1alpha1"
 	genv1alpha1 "github.com/external-secrets/external-secrets/apis/generators/v1alpha1"
@@ -92,6 +91,7 @@ var (
 	certLookaheadInterval                 time.Duration
 	tlsCiphers                            string
 	tlsMinVersion                         string
+	watchNamespaces						  []string
 )
 
 const (
@@ -152,10 +152,18 @@ var rootCmd = &cobra.Command{
 			LeaderElection:   enableLeaderElection,
 			LeaderElectionID: "external-secrets-controller",
 		}
+		// Namespaced mode takes precedence
 		if namespace != "" {
 			mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 				namespace: {},
 			}
+		} else if len(watchNamespaces) > 0 {
+			// Cluster-scoped mode but limited to specific namespaces
+			nsMap := make(map[string]cache.Config, len(watchNamespaces))
+			for _, ns := range watchNamespaces {
+				nsMap[ns] = cache.Config{}
+			}
+			mgrOpts.Cache.DefaultNamespaces = nsMap
 		}
 		mgr, err := ctrl.NewManager(config, mgrOpts)
 		if err != nil {
@@ -329,6 +337,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&enableFloodGate, "enable-flood-gate", true, "Enable flood gate. External secret will be reconciled only if the ClusterStore or Store have an healthy or unknown state.")
 	rootCmd.Flags().BoolVar(&enableGeneratorState, "enable-generator-state", true, "Whether the Controller should manage GeneratorState")
 	rootCmd.Flags().BoolVar(&enableExtendedMetricLabels, "enable-extended-metric-labels", false, "Enable recommended kubernetes annotations as labels in metrics.")
+	rootCmd.Flags().StringSliceVar(&watchNamespaces, "watch-namespaces", nil, "Comma-separated list of namespaces to limit ESO to watch only the provided list of namespaces when deployed in cluster wide mode instead of watching all the namespaces which is the default behavior")
 	fs := feature.Features()
 	for _, f := range fs {
 		rootCmd.Flags().AddFlagSet(f.Flags)

--- a/deploy/charts/external-secrets/README.md
+++ b/deploy/charts/external-secrets/README.md
@@ -174,6 +174,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |
+| watchNamespaces | list | `[]` | If set, the controller will watch only the provided namespaces, reconcile external secrets only in those namespaces, and implicitly disable cluster stores, cluster external secrets and cluster push secrets. If this feature is used and create.rbac is set to true, then a Role and RoleBinding will be deployed in each watched namespace. |
 | webhook.affinity | object | `{}` |  |
 | webhook.annotations | object | `{}` | Annotations to place on validating webhook configuration. |
 | webhook.certCheckInterval | string | `"5m"` | Specifices the time to check if the cert is valid |

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           {{- if .Values.scopedNamespace }}
           - --namespace={{ .Values.scopedNamespace }}
           {{- end }}
+          {{- if .Values.watchNamespaces }}
+          - --watch-namespaces={{join "," .Values.watchNamespaces}}
+          {{- end }}
           {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
           - --enable-cluster-store-reconciler=false
           - --enable-cluster-external-secret-reconciler=false

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -61,8 +61,9 @@ spec:
           {{- end }}
           {{- if .Values.watchNamespaces }}
           - --watch-namespaces={{join "," .Values.watchNamespaces}}
+          - --enable-secrets-caching=true
           {{- end }}
-          {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+          {{- if or (and .Values.scopedNamespace .Values.scopedRBAC) .Values.watchNamespaces }}
           - --enable-cluster-store-reconciler=false
           - --enable-cluster-external-secret-reconciler=false
           - --enable-cluster-push-secret-reconciler=false

--- a/deploy/charts/external-secrets/templates/rbac-per-namespace.yaml
+++ b/deploy/charts/external-secrets/templates/rbac-per-namespace.yaml
@@ -1,0 +1,155 @@
+{{- if and .Values.rbac.create .Values.watchNamespaces }}
+{{- range $ns := uniq .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "external-secrets.fullname" $ }}
+  namespace: {{ $ns }}
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "secretstores"
+    - "externalsecrets"
+    {{- if $.Values.processPushSecret }}
+    - "pushsecrets"
+    {{- end }}
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    - "externalsecrets/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "externalsecrets/finalizers"
+    {{- end }}
+    - "secretstores"
+    - "secretstores/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "secretstores/finalizers"
+    {{- end }}
+    {{- if $.Values.processPushSecret }}
+    - "pushsecrets"
+    - "pushsecrets/status"
+    {{- if $.Values.openshiftFinalizers }}
+    - "pushsecrets/finalizers"
+    {{- end }}
+    {{- end }}
+    verbs:
+    - "get"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "generatorstates"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "deletecollection"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "githubaccesstokens"
+    - "quayaccesstokens"
+    - "passwords"
+    - "stssessiontokens"
+    - "uuids"
+    - "vaultdynamicsecrets"
+    - "webhooks"
+    - "grafanas"
+    - "mfas"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts"
+    - "namespaces"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts/token"
+    verbs:
+    - "create"
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
+  {{- if $.Values.processPushSecret }}
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "pushsecrets"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
+  {{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "external-secrets.fullname" $ }}
+  namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "external-secrets.fullname" $ }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "external-secrets.serviceAccountName" $ }}
+    namespace: {{ template "external-secrets.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and (.Values.rbac.create) (not .Values.watchNamespaces) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
 kind: Role

--- a/deploy/charts/external-secrets/values.schema.json
+++ b/deploy/charts/external-secrets/values.schema.json
@@ -626,6 +626,9 @@
         "topologySpreadConstraints": {
             "type": "array"
         },
+        "watchNamespaces": {
+            "type": "array"
+        },
         "webhook": {
             "type": "object",
             "properties": {

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -78,7 +78,10 @@ scopedNamespace: ""
 # and implicitly disable cluster stores and cluster external secrets
 scopedRBAC: false
 
-# -- If set controller will watch only the provided namespaces
+# -- If set, the controller will watch only the provided namespaces, reconcile external secrets
+# only in those namespaces, and implicitly disable cluster stores, cluster external secrets
+# and cluster push secrets. If this feature is used and create.rbac is set to true, then a Role and RoleBinding will be
+# deployed in each watched namespace.
 watchNamespaces: []
 
 # -- If true the OpenShift finalizer permissions will be added to RBAC

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -78,6 +78,9 @@ scopedNamespace: ""
 # and implicitly disable cluster stores and cluster external secrets
 scopedRBAC: false
 
+# -- If set controller will watch only the provided namespaces
+watchNamespaces: []
+
 # -- If true the OpenShift finalizer permissions will be added to RBAC
 openshiftFinalizers: true
 


### PR DESCRIPTION
## Limit ESO to watch a list namespaces

Add an option `--watch-namespaces` to limit the scope of the operator when deployed in cluster wide mode.

This option is used to configure a list of namespaces that will be watched by ESO.

If rbac.create is set to true, a Role and a RoleBinding will be deploed in each watched namespace to give permissions to ESO service account.
