### PR TITLE
fix: when watch-namespaces is used and the global secrets caching is …

### DIFF
--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -157,8 +157,8 @@ var rootCmd = &cobra.Command{
 			mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 				namespace: {},
 			}
+		// Multi-namespace mode limited to specific list of namespaces
 		} else if len(watchNamespaces) > 0 {
-			// Cluster-scoped mode but limited to specific namespaces
 			nsMap := make(map[string]cache.Config, len(watchNamespaces))
 			for _, ns := range watchNamespaces {
 				nsMap[ns] = cache.Config{}
@@ -177,7 +177,7 @@ var rootCmd = &cobra.Command{
 		// if we are already caching all secrets, we don't need to use the special client.
 		secretClient := mgr.GetClient()
 		if enableManagedSecretsCache && !enableSecretsCache {
-			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr, namespace)
+			secretClient, err = ctrlcommon.BuildManagedSecretClient(mgr, namespace, watchNamespaces)
 			if err != nil {
 				setupLog.Error(err, "unable to create managed secret client")
 				os.Exit(1)
@@ -337,7 +337,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&enableFloodGate, "enable-flood-gate", true, "Enable flood gate. External secret will be reconciled only if the ClusterStore or Store have an healthy or unknown state.")
 	rootCmd.Flags().BoolVar(&enableGeneratorState, "enable-generator-state", true, "Whether the Controller should manage GeneratorState")
 	rootCmd.Flags().BoolVar(&enableExtendedMetricLabels, "enable-extended-metric-labels", false, "Enable recommended kubernetes annotations as labels in metrics.")
-	rootCmd.Flags().StringSliceVar(&watchNamespaces, "watch-namespaces", nil, "Comma-separated list of namespaces to limit ESO to watch only the provided list of namespaces when deployed in cluster wide mode instead of watching all the namespaces which is the default behavior")
+	rootCmd.Flags().StringSliceVar(&watchNamespaces, "watch-namespaces", nil, "Comma-separated list of namespaces to limit ESO to watch only the provided list of namespaces when deployed in multi-namespace mode instead of watching all the namespaces which is the default behavior")
 	fs := feature.Features()
 	for _, f := range fs {
 		rootCmd.Flags().AddFlagSet(f.Flags)

--- a/deploy/charts/external-secrets/templates/deployment.yaml
+++ b/deploy/charts/external-secrets/templates/deployment.yaml
@@ -61,7 +61,6 @@ spec:
           {{- end }}
           {{- if .Values.watchNamespaces }}
           - --watch-namespaces={{join "," .Values.watchNamespaces}}
-          - --enable-secrets-caching=true
           {{- end }}
           {{- if or (and .Values.scopedNamespace .Values.scopedRBAC) .Values.watchNamespaces }}
           - --enable-cluster-store-reconciler=false

--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -32,7 +32,7 @@ import (
 )
 
 // BuildManagedSecretClient creates a new client that only sees secrets with the "managed" label.
-func BuildManagedSecretClient(mgr ctrl.Manager, namespace string) (client.Client, error) {
+func BuildManagedSecretClient(mgr ctrl.Manager, namespace string, watchNamespaces []string) (client.Client, error) {
 	// secrets we manage will have the `reconcile.external-secrets.io/managed=true` label
 	managedLabelReq, _ := labels.NewRequirement(esv1.LabelManaged, selection.Equals, []string{esv1.LabelManagedValue})
 	managedLabelSelector := labels.NewSelector().Add(*managedLabelReq)
@@ -56,6 +56,12 @@ func BuildManagedSecretClient(mgr ctrl.Manager, namespace string) (client.Client
 		secretCacheOpts.DefaultNamespaces = map[string]cache.Config{
 			namespace: {},
 		}
+	} else if len(watchNamespaces) > 0 {
+		nsMap := make(map[string]cache.Config, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			nsMap[ns] = cache.Config{}
+		}
+		secretCacheOpts.DefaultNamespaces = nsMap
 	}
 
 	secretCache, err := cache.New(mgr.GetConfig(), secretCacheOpts)

--- a/pkg/controllers/externalsecret/suite_test.go
+++ b/pkg/controllers/externalsecret/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 
 	// by default, we use a separate cached client for secrets that are managed by the controller
 	// so we should test under the same conditions
-	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager, "")
+	secretClient, err := ctrlcommon.BuildManagedSecretClient(k8sManager, "", []string{})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Reconciler{


### PR DESCRIPTION
## Problem Statement

There are two important ESO CLI flags : 

1. `--enable-managed-secrets-caching` is used to enable/disable the  caching of only the managed secrets (secrets created by ESO)
2. `--enable-secrets-caching` is used to enable/disable the caching off all the secrets

When `--enable-secrets-caching` is set to **true**, no matter of `--enable-managed-secrets-caching`, Only the manager client will be used which is already scoped to the provided list of namespaces (when watch-namespaces is used)

The problem is : 

- When `--enable-managed-secrets-caching=true` and `--enable-secrets-caching=false` , here a special secret client is created (the managed secret client), and this client is not scoped to the provided list of namespaces (when watch-namespaces is used). In this case the client will do cluster wide Kubernetes requests on Secrets. So the fix is to scope the cache of this managed client to the provided list of namespaces

